### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # @xiaok/etherscan-mcp
 
+A dynamic MCP server for interacting with Etherscan's API and services.
+
+<a href="https://glama.ai/mcp/servers/@xiaok/etherscan-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@xiaok/etherscan-mcp/badge" alt="Etherscan MCP server" />
+</a>
 
 ## Running Your Server
 


### PR DESCRIPTION
This PR adds a badge for the [Etherscan MCP](https://glama.ai/mcp/servers/@xiaok/etherscan-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@xiaok/etherscan-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@xiaok/etherscan-mcp/badge" alt="Etherscan MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.